### PR TITLE
Upgrade to Kafka Connect 4.1.0 compatibility (v1.6.4-formstack)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
   <groupId>com.nordstrom.kafka.connect.sqs</groupId>
   <artifactId>kafka-connect-sqs</artifactId>
   <name>Kafka Connect SQS Sink/Source Connector</name>
-  <version>1.6.3-formstack</version>
+  <version>1.6.4-formstack</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
 
     <!-- latest version as of 2019-01 -->
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
@@ -42,7 +42,7 @@
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
 
     <aws-java-sdk.version>1.12.778</aws-java-sdk.version>
-    <kafka.connect-api.version>3.4.1</kafka.connect-api.version>
+    <kafka.connect-api.version>4.1.0</kafka.connect-api.version>
     <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
@@ -120,6 +120,7 @@
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2019 Nordstrom, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -41,7 +41,7 @@ public class SqsSourceConnectorTask extends SourceTask {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.apache.kafka.connect.connector.Task#version()
    */
   @Override
@@ -51,7 +51,7 @@ public class SqsSourceConnectorTask extends SourceTask {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.apache.kafka.connect.source.SourceTask#start(java.util.Map)
    */
   @Override
@@ -92,7 +92,7 @@ public class SqsSourceConnectorTask extends SourceTask {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.apache.kafka.connect.source.SourceTask#poll()
    */
   @Override
@@ -154,8 +154,25 @@ public class SqsSourceConnectorTask extends SourceTask {
   @Override
   public void commitRecord( SourceRecord record, RecordMetadata metadata ) throws InterruptedException {
     Guard.verifyNotNull( record, "record" ) ;
-    final String receipt = record.sourceOffset().get( SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue() )
-        .toString() ;
+
+    final Map<String, ?> sourceOffset = record.sourceOffset() ;
+    if ( sourceOffset == null ) {
+      log.error( ".commit-record:source-offset-is-null, cannot-delete-sqs-message, partition={}, offset={}",
+          metadata != null ? metadata.partition() : "unknown",
+          metadata != null ? metadata.offset() : "unknown" ) ;
+      throw new IllegalStateException( "Source offset is null, cannot delete SQS message" ) ;
+    }
+
+    final Object receiptHandleObj = sourceOffset.get( SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue() ) ;
+    if ( receiptHandleObj == null ) {
+      log.error( ".commit-record:missing-receipt-handle-in-source-offset, offset={}, partition={}, offset={}",
+          sourceOffset,
+          metadata != null ? metadata.partition() : "unknown",
+          metadata != null ? metadata.offset() : "unknown" ) ;
+      throw new IllegalStateException( "Missing receipt handle in source offset, cannot delete SQS message" ) ;
+    }
+
+    final String receipt = receiptHandleObj.toString() ;
     log.debug( ".commit-record:url={}, receipt-handle={}, partition={}, offset={}",
         config.getQueueUrl(), receipt,
         metadata != null ? metadata.partition() : "unknown",
@@ -166,7 +183,7 @@ public class SqsSourceConnectorTask extends SourceTask {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.apache.kafka.connect.source.SourceTask#stop()
    */
   @Override
@@ -177,7 +194,7 @@ public class SqsSourceConnectorTask extends SourceTask {
   /**
    * Test that we have both the task configuration and SQS client properly
    * initialized.
-   * 
+   *
    * @return true if task is in a valid state.
    */
   private boolean isValidState() {

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors ;
 
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.nordstrom.kafka.connect.utils.StringUtils;
+import org.apache.kafka.clients.producer.RecordMetadata ;
 import org.apache.kafka.connect.data.Schema ;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.header.ConnectHeaders;
@@ -148,16 +149,19 @@ public class SqsSourceConnectorTask extends SourceTask {
   }
 
   /* (non-Javadoc)
-   * @see org.apache.kafka.connect.source.SourceTask#commitRecord(org.apache.kafka.connect.source.SourceRecord)
+   * @see org.apache.kafka.connect.source.SourceTask#commitRecord(org.apache.kafka.connect.source.SourceRecord, org.apache.kafka.clients.producer.RecordMetadata)
    */
   @Override
-  public void commitRecord( SourceRecord record ) throws InterruptedException {
+  public void commitRecord( SourceRecord record, RecordMetadata metadata ) throws InterruptedException {
     Guard.verifyNotNull( record, "record" ) ;
     final String receipt = record.sourceOffset().get( SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue() )
         .toString() ;
-    log.debug( ".commit-record:url={}, receipt-handle={}", config.getQueueUrl(), receipt ) ;
+    log.debug( ".commit-record:url={}, receipt-handle={}, partition={}, offset={}",
+        config.getQueueUrl(), receipt,
+        metadata != null ? metadata.partition() : "unknown",
+        metadata != null ? metadata.offset() : "unknown" ) ;
     client.delete( config.getQueueUrl(), receipt ) ;
-    super.commitRecord( record ) ;
+    super.commitRecord( record, metadata ) ;
   }
 
   /*


### PR DESCRIPTION
This release updates the connector to be compatible with Kafka Connect 4.0.0+ by updating the deprecated commitRecord method signature.

Changes:
- Update commitRecord(SourceRecord) to commitRecord(SourceRecord, RecordMetadata)
- Add RecordMetadata import
- Update Kafka Connect API dependency from 3.4.1 to 4.1.0
- Update Java version from 8 to 11 (required for Kafka 4.x)
- Bump version to 1.6.4-formstack

This fixes the issue where messages were not being deleted from SQS after successful processing due to the commitRecord method never being called in Kafka Connect 4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)